### PR TITLE
Update open folder logic for FileInputWidget

### DIFF
--- a/sept_qt/file_input_widget.py
+++ b/sept_qt/file_input_widget.py
@@ -134,6 +134,9 @@ class FileTemplateInputWidget(TemplateInputWidget):
         elif os.path.isdir(self._disk_path):
             if os.path.exists(self._disk_path):
                 path = self._disk_path
+        elif os.path.isdir(os.path.dirname(self._disk_path)):
+            if os.path.exists(os.path.dirname(self._disk_path)):
+                path = os.path.dirname(self._disk_path)
         return path
 
     @QtCore.Slot()


### PR DESCRIPTION
If you have passed in a path you expect to exist but the sept template
file doesn't exist on disk, previously we would fallback to opening your
cwd however we have now added one additional check in there.

If you don't have the _disk_path on disk but you do have it's containing
folder, we will open the containing folder even though the exact sept
template file doesn't exist within it.